### PR TITLE
fix: leave classroom modal text not centered

### DIFF
--- a/islands/beta/LeaveClassroom.tsx
+++ b/islands/beta/LeaveClassroom.tsx
@@ -99,7 +99,7 @@ export function LeaveClassroom({ classroomId }: Props) {
 								<path d="M12 17h.01" />
 							</svg>
 						</div>
-						<div class="flex flex-col items-center gap-0 mt-4">
+						<div class="flex flex-col items-center gap-0 mt-4 text-center">
 							<p class="font-semibold">
 								Are you sure want to leave this classroom?
 							</p>

--- a/routes/beta/classrooms/[[classroomId]]/_layout.tsx
+++ b/routes/beta/classrooms/[[classroomId]]/_layout.tsx
@@ -17,7 +17,7 @@ export default define.page((ctx) => {
 
 	return (
 		<div
-			class="flex flex-col md:flex-row h-full font-[Outfit] select-none overflow-y-auto no-scrollbar"
+			class="flex flex-col md:flex-row h-full font-[Outfit] select-none overflow-x-hidden overflow-y-auto no-scrollbar"
 			f-client-nav
 		>
 			<div class="flex flex-col grow p-4 overflow-y-auto">


### PR DESCRIPTION
fix #14 